### PR TITLE
Correctly add Pyrolusite to the dustManganeseDioxide Oredict

### DIFF
--- a/scripts/ore_dicts/ore_dict.zs
+++ b/scripts/ore_dicts/ore_dict.zs
@@ -60,7 +60,8 @@ function unify (ore as IOreDictEntry, p as int) {
 <ore:gemCertusQuartz>.remove(<ore:gemCertusQuartz>.firstItem);
 
 // Manganese Dioxide Compatibility
-<ore:dustManganeseDioxide>.add(<metaitem:dustRegularPyrolusite>);
+val pyrolusite = <gregtech:meta_item_1:2149>;
+<ore:dustManganeseDioxide>.add(pyrolusite);
 
 unify_oredicts(<ore:ingot*>);
 unify_oredicts(<ore:plate*>);

--- a/scripts/ore_dicts/ore_dict.zs
+++ b/scripts/ore_dicts/ore_dict.zs
@@ -60,8 +60,10 @@ function unify (ore as IOreDictEntry, p as int) {
 <ore:gemCertusQuartz>.remove(<ore:gemCertusQuartz>.firstItem);
 
 // Manganese Dioxide Compatibility
-val pyrolusite = <gregtech:meta_item_1:2149>;
-<ore:dustManganeseDioxide>.add(pyrolusite);
+<ore:dustManganeseDioxide>.add(<ore:dustRegularPyrolusite>.firstItem);
+
+// NC Bioplastic -> Polystyrene
+<ore:bioplastic>.add(<ore:platePolystyrene>.firstItem); 
 
 unify_oredicts(<ore:ingot*>);
 unify_oredicts(<ore:plate*>);
@@ -71,6 +73,7 @@ unify_oredicts(<ore:gear*>);
 unify_oredicts(<ore:stick*>);
 unify_oredicts(<ore:crystal*>);
 unify_oredicts(<ore:nugget*>);
+unify_oredicts(<ore:bioplastic>);
 
 
 unify(<ore:itemSilicon>, 0);


### PR DESCRIPTION
Previously, Pyrolusite was incorrectly accessed when I attempted to merge it with the dustManganeseDioxide Oredict from NuclearCraft, which caused the alloying recipe between Lithium and Manganese Dioxide to not work with Pyrolusite. This pull request fixes this issue.