### PR TITLE
Disable Quark Chest

### DIFF
--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -566,9 +566,9 @@ decoration {
     B:Rope=true
     B:"Tallow and candles"=true
     B:"Tie fences"=true
-    B:"Varied bookshelves"=true
+    B:"Varied bookshelves"=false
     B:"Varied buttons and pressure plates"=true
-    B:"Varied chests"=true
+    B:"Varied chests"=false
     B:"Varied trapdoors"=true
 
     "more banners" {
@@ -622,12 +622,12 @@ decoration {
     }
 
     "varied chests" {
-        B:"Add recipe to craft chests using Logs (makes 4 chests)"=true
+        B:"Add recipe to craft chests using Logs (makes 4 chests)"=false
 
         # Set this to true to add a recipe to convert any Quark chest to a vanilla one.
         # Use this if some of your mods don't work with the ore dictionary key "chestWood".
         B:"Enable Conversion to Vanilla Chests"=false
-        B:"Rename vanilla chests to Oak (Trapped) Chest"=true
+        B:"Rename vanilla chests to Oak (Trapped) Chest"=false
     }
 
     "more banner layers" {

--- a/scripts/jei_cleaning.zs
+++ b/scripts/jei_cleaning.zs
@@ -10,7 +10,6 @@ val name_removals = [
     "enderio:tweak_stick_from_wood",
     "enderio:ender_defragmentation",
     "minecraft:bookshelf",
-    "minecraft:chest",
     "buildinggadgets:templatemanager"
 ] as string[];
 


### PR DESCRIPTION
Disabling Quark chests variants for input bus recipes, among other.
Disabling wood log to chest recipe. Reenabling vanilla chest recipe (not sure why that was removed as we didn't have any override).
Disabling Quark bookshelves in favor in Chisel shelves.