### PR TITLE
Update kaolinite_vein.json

### DIFF
--- a/config/gregtech/worldgen/advanced-rocketry/moon/poor_tungstate_vein.json
+++ b/config/gregtech/worldgen/advanced-rocketry/moon/poor_tungstate_vein.json
@@ -11,7 +11,7 @@
     "radius": [8, 8]
   },
   "filler": {
-    "type": "simple",
+    "type": "ga_simple",
     "value": {
       "type": "weight_random",
       "values": [

--- a/config/gregtech/worldgen/nether/magnetite_vein2.json
+++ b/config/gregtech/worldgen/nether/magnetite_vein2.json
@@ -3,7 +3,7 @@
   "density": 0.3,
   "max_height": 120,
   "min_height": 50,
-  "dimension_filter": ["is_nether"],
+  "dimension_filter": ["is_nether", "dimension_id:0"],
   "surface_stone_material": "gold",
 
   "generator": {

--- a/config/gregtech/worldgen/nether/magnetite_vein2.json
+++ b/config/gregtech/worldgen/nether/magnetite_vein2.json
@@ -3,7 +3,7 @@
   "density": 0.3,
   "max_height": 120,
   "min_height": 50,
-  "dimension_filter": ["is_nether","dimension_filter:0"],
+  "dimension_filter": ["is_nether"],
   "surface_stone_material": "gold",
 
   "generator": {

--- a/config/gregtech/worldgen/overworld/kaolinite_vein.json
+++ b/config/gregtech/worldgen/overworld/kaolinite_vein.json
@@ -1,0 +1,35 @@
+{
+  "weight": 60,
+  "density": 0.5,
+  "max_height": 70,
+  "min_height": 50,
+
+  "generator": {
+    "type": "ellipsoid",
+    "radius": [13, 13]
+  },
+  "filler": {
+    "type": "simple",
+    "value": {
+      "type": "weight_random",
+      "values": [
+        {
+          "weight": 30,
+          "value": "ore:kaolinite"
+        },
+        {
+          "weight": 30,
+          "value": "ore:bentonite"
+        },
+        {
+          "weight": 20,
+          "value": "ore:zeolite"
+        },
+        {
+          "weight": 20,
+          "value": "ore:fullers_earth"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes an issue with the worldgen, where the kaolinite vein file was null, preventing the files after it from being processed.
Also, I replaced glauconite sand in this with bentonite, since that can be used along with kaolinite in a higher-output adobe bricks recipe for GTFO.